### PR TITLE
Add Prisma client wrapper and refine schedules API

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,3 +6,14 @@ datasource db {
   provider = "sqlite"
   url      = "file:./dev.db"
 }
+
+model EventSchedule {
+  id                Int      @id @default(autoincrement())
+  startDateTime     DateTime
+  endDateTime       DateTime
+  eventName         String
+  responsibleName   String
+  responsiblePhone  String
+  description       String
+  price             Float
+}

--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  try {
+    const events = await prisma.eventSchedule.findMany({
+      orderBy: { startDateTime: 'asc' },
+    })
+
+    const formatPrice = (value: number) =>
+      new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value)
+
+    const result = events.map(event => ({
+      id: event.id,
+      startDateTime: event.startDateTime.toLocaleString('pt-BR'),
+      endDateTime: event.endDateTime.toLocaleString('pt-BR'),
+      eventName: event.eventName,
+      responsibleName: event.responsibleName,
+      responsiblePhone: event.responsiblePhone,
+      description: event.description,
+      price: formatPrice(event.price),
+    }))
+
+    return NextResponse.json(result)
+  } catch (error) {
+    return NextResponse.json({ error: 'Falha ao buscar agendamentos' }, { status: 500 })
+  }
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined }
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma


### PR DESCRIPTION
## Summary
- add shared Prisma instance in `src/lib/prisma.ts`
- improve `/api/schedules` to format price in BRL and return PT-BR errors

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx prisma format` *(fails: 403 Forbidden fetching npm package)*

------
https://chatgpt.com/codex/tasks/task_e_68880a92c6c883298db89212f2bb1aed