### PR TITLE
Implement schedule creation and snackbar

### DIFF
--- a/src/app/agendamentos/cadastrar/page.tsx
+++ b/src/app/agendamentos/cadastrar/page.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import axios from 'axios'
+import { useRouter } from 'next/navigation'
+import { useSnackbar } from '@/providers/SnackbarProvider'
+import Input from '@/components/Input'
+import Button from '@/components/Button'
+
+const formSchema = z.object({
+  eventName: z.string().min(1, 'Informe o nome do evento'),
+  description: z.string().min(1, 'Informe a descri\u00e7\u00e3o'),
+  responsibleName: z.string().min(1, 'Informe o respons\u00e1vel'),
+  responsiblePhone: z.string().min(1, 'Informe o telefone'),
+  startDateTime: z.string().min(1, 'Informe a data de in\u00edcio'),
+  endDateTime: z.string().min(1, 'Informe a data de t\u00e9rmino'),
+  price: z.string().min(1, 'Informe o valor'),
+})
+
+type FormData = z.infer<typeof formSchema>
+
+export default function CreateSchedulePage() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({ resolver: zodResolver(formSchema) })
+  const router = useRouter()
+  const { showSnackbar } = useSnackbar()
+
+  async function onSubmit(data: FormData) {
+    try {
+      const res = await axios.post('/api/schedules', data)
+      showSnackbar(res.data.message, 'success')
+      router.push('/agendamentos')
+    } catch (err: any) {
+      const message = err.response?.data?.error || 'Erro ao cadastrar'
+      showSnackbar(message, 'error')
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="p-4 max-w-md mx-auto space-y-4"
+    >
+      <div>
+        <Input {...register('eventName')} placeholder="Nome do evento" />
+        {errors.eventName && (
+          <p className="text-red-500 text-sm">{errors.eventName.message}</p>
+        )}
+      </div>
+      <div>
+        <textarea
+          {...register('description')}
+          placeholder="Descri\u00e7\u00e3o"
+          className="border rounded w-full p-2"
+        />
+        {errors.description && (
+          <p className="text-red-500 text-sm">{errors.description.message}</p>
+        )}
+      </div>
+      <div>
+        <Input {...register('responsibleName')} placeholder="Responsável" />
+        {errors.responsibleName && (
+          <p className="text-red-500 text-sm">{errors.responsibleName.message}</p>
+        )}
+      </div>
+      <div>
+        <Input {...register('responsiblePhone')} placeholder="Telefone" />
+        {errors.responsiblePhone && (
+          <p className="text-red-500 text-sm">{errors.responsiblePhone.message}</p>
+        )}
+      </div>
+      <div>
+        <Input type="datetime-local" {...register('startDateTime')} />
+        {errors.startDateTime && (
+          <p className="text-red-500 text-sm">{errors.startDateTime.message}</p>
+        )}
+      </div>
+      <div>
+        <Input type="datetime-local" {...register('endDateTime')} />
+        {errors.endDateTime && (
+          <p className="text-red-500 text-sm">{errors.endDateTime.message}</p>
+        )}
+      </div>
+      <div>
+        <Input {...register('price')} placeholder="Valor" />
+        {errors.price && (
+          <p className="text-red-500 text-sm">{errors.price.message}</p>
+        )}
+      </div>
+      <Button type="submit">Cadastrar</Button>
+    </form>
+  )
+}

--- a/src/app/agendamentos/page.tsx
+++ b/src/app/agendamentos/page.tsx
@@ -1,9 +1,11 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { useSchedules } from '@/hooks/useSchedules'
 import Loading from '@/components/Loading'
 import ErrorMessage from '@/components/ErrorMessage'
+import Input from '@/components/Input'
 
 export default function AgendamentosPage() {
   const { data: schedules = [], isLoading, error } = useSchedules()
@@ -25,19 +27,22 @@ export default function AgendamentosPage() {
 
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Agendamentos</h1>
-      <input
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold">Agendamentos</h1>
+        <Link href="/agendamentos/cadastrar" className="text-blue-500">Novo</Link>
+      </div>
+      <Input
         type="text"
         value={search}
         onChange={e => setSearch(e.target.value)}
-        className="border rounded w-full p-2 mb-4"
+        className="mb-4"
         placeholder="Buscar por evento ou responsável"
       />
-      <input
+      <Input
         type="date"
         value={date}
         onChange={e => setDate(e.target.value)}
-        className="border rounded w-full p-2 mb-4"
+        className="mb-4"
       />
       <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
         {filtered.map(schedule => (

--- a/src/app/api/schedules/post.type.ts
+++ b/src/app/api/schedules/post.type.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { prisma } from '@/lib/prisma'
+
+const bodySchema = z.object({
+  startDateTime: z.string(),
+  endDateTime: z.string(),
+  eventName: z.string(),
+  responsibleName: z.string(),
+  responsiblePhone: z.string(),
+  description: z.string(),
+  price: z.string(),
+})
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const data = bodySchema.parse(body)
+
+    const schedule = await prisma.eventSchedule.create({
+      data: {
+        startDateTime: new Date(data.startDateTime),
+        endDateTime: new Date(data.endDateTime),
+        eventName: data.eventName,
+        responsibleName: data.responsibleName,
+        responsiblePhone: data.responsiblePhone,
+        description: data.description,
+        price: parseFloat(data.price),
+      },
+    })
+
+    return NextResponse.json({ message: 'Agendamento criado com sucesso', id: schedule.id })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: 'Dados inv\u00e1lidos' }, { status: 400 })
+    }
+    console.error(error)
+    return NextResponse.json({ error: 'Falha ao criar agendamento' }, { status: 500 })
+  }
+}

--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -1,1 +1,2 @@
 export { GET } from './get.type'
+export { POST } from './post.type'

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,15 @@
 import './globals.css'
 import { ReactNode } from 'react'
 import QueryProvider from '@/providers/QueryProvider'
+import SnackbarProvider from '@/providers/SnackbarProvider'
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="pt-br">
       <body>
-        <QueryProvider>{children}</QueryProvider>
+        <QueryProvider>
+          <SnackbarProvider>{children}</SnackbarProvider>
+        </QueryProvider>
       </body>
     </html>
   )

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,16 @@
+'use client'
+import { forwardRef, ButtonHTMLAttributes } from 'react'
+
+const Button = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement>>(function Button(
+  { className = '', ...props }, ref
+) {
+  return (
+    <button
+      ref={ref}
+      {...props}
+      className={`bg-blue-500 text-white px-4 py-2 rounded ${className}`}
+    />
+  )
+})
+
+export default Button

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,16 @@
+'use client'
+import { forwardRef, InputHTMLAttributes } from 'react'
+
+const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(function Input(
+  { className = '', ...props }, ref
+) {
+  return (
+    <input
+      ref={ref}
+      {...props}
+      className={`border rounded w-full p-2 ${className}`}
+    />
+  )
+})
+
+export default Input

--- a/src/providers/SnackbarProvider.tsx
+++ b/src/providers/SnackbarProvider.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { createContext, ReactNode, useContext, useState } from 'react'
+
+type SnackbarType = 'success' | 'error' | 'warning'
+
+interface SnackbarState {
+  open: boolean
+  message: string
+  type: SnackbarType
+}
+
+interface SnackbarContextProps {
+  showSnackbar: (message: string, type?: SnackbarType) => void
+}
+
+const SnackbarContext = createContext<SnackbarContextProps>({
+  showSnackbar: () => {},
+})
+
+export function useSnackbar() {
+  return useContext(SnackbarContext)
+}
+
+export default function SnackbarProvider({ children }: { children: ReactNode }) {
+  const [snackbar, setSnackbar] = useState<SnackbarState>({
+    open: false,
+    message: '',
+    type: 'success',
+  })
+
+  const showSnackbar = (message: string, type: SnackbarType = 'success') => {
+    setSnackbar({ open: true, message, type })
+    setTimeout(() => {
+      setSnackbar(s => ({ ...s, open: false }))
+    }, 3000)
+  }
+
+  const bgColor =
+    snackbar.type === 'success'
+      ? 'bg-green-500'
+      : snackbar.type === 'error'
+      ? 'bg-red-500'
+      : 'bg-yellow-500'
+
+  return (
+    <SnackbarContext.Provider value={{ showSnackbar }}>
+      {children}
+      {snackbar.open && (
+        <div
+          className={
+            bgColor +
+            ' fixed bottom-4 left-1/2 -translate-x-1/2 text-white px-4 py-2 rounded shadow'
+          }
+        >
+          {snackbar.message}
+        </div>
+      )}
+    </SnackbarContext.Provider>
+  )
+}


### PR DESCRIPTION
## Summary
- create SnackbarProvider for notifications
- wrap app layout with SnackbarProvider
- add POST /api/schedules endpoint with zod validation
- create schedule form page
- link to create schedule from schedules list
- componentize button and input usage

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888129e85348329a3c43c655b94420d